### PR TITLE
Fix package

### DIFF
--- a/helm-cider.el
+++ b/helm-cider.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016 Tianxiang Xiong
 
 ;; Author: Tianxiang Xiong <tianxiang.xiong@gmail.com>
-;; Package-Requires: ((emacs "24.4") (cider "0.12") (cl-lib "0.5") (helm-core "1.9") (seq "1.0"))
+;; Package-Requires: ((emacs "24.4") (cider "0.12") (helm-core "1.9") (seq "1.0"))
 ;; Keywords: tools, convenience
 ;; URL: https://github.com/clojure-emacs/helm-cider
 ;; Version: 0.1.0

--- a/helm-cider.el
+++ b/helm-cider.el
@@ -32,6 +32,7 @@
 
 (require 'cider)
 (require 'cl-lib)
+(require 'helm)
 (require 'helm-lib)
 (require 'helm-multi-match)
 (require 'helm-source)

--- a/helm-cider.el
+++ b/helm-cider.el
@@ -137,7 +137,7 @@ TYPE values include \"function\", \"macro\", etc."
   "Sort Helm sources by name in ascending order.
 
 If DESCENDING is true, sort in descending order."
-  (let ((fn (if descending #'string> #'string<)))
+  (let ((fn (if descending (lambda (a b) (string< b a)) #'string<)))
     (lambda (s1 s2)
       (funcall fn (assoc-default 'name s1) (assoc-default 'name s2)))))
 


### PR DESCRIPTION
- Remove redundant dependency
- Load `helm.el` for byte-compile warnings
- Don't use `string>` for older Emacs. `string>` was introduced since Emacs 25.
