### PR TITLE
Remove cider-compat from helm-cider-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Changed
+- [#13](https://github.com/clojure-emacs/helm-cider/pull/13): remove cider-compat require (removed from cider)
+
 ### New features
 
 - [#10](https://github.com/clojure-emacs/helm-cider/pull/10): Port `clojure-cheatsheet`

--- a/helm-cider-spec.el
+++ b/helm-cider-spec.el
@@ -24,7 +24,6 @@
 ;;; Code:
 
 (require 'cider-client)
-(require 'cider-compat)
 (require 'cl-lib)
 (require 'helm-cider-util)
 (require 'subr-x)


### PR DESCRIPTION
`cider-compat` namespace has been removed from `clojure-emacs/cider` and helm-cider
prevent Emacs loading Clojure files due to the missing namespace

Removing `(require 'cider-compat)` from helm-cider-spec.el resolves the issue without breaking functionality in helm-cider

Resolve #12