### PR TITLE
Require `helm` for REPL history completion

### DIFF
--- a/helm-cider-repl.el
+++ b/helm-cider-repl.el
@@ -26,6 +26,7 @@
 (require 'cider-repl)
 (require 'cl-lib)
 (require 'subr-x)
+(require 'helm)
 
 
 ;;;; Customize


### PR DESCRIPTION
I got an error `invalid function helm-build-sync-source` when `helm` is not loaded.