### PR TITLE
Load helm-core.el instead of helm.el

### DIFF
--- a/helm-cider-cheatsheet.el
+++ b/helm-cider-cheatsheet.el
@@ -29,7 +29,7 @@
 (require 'cider)
 (require 'cider-cheatsheet)
 (require 'cl-lib)
-(require 'helm)
+(require 'helm-core)
 (require 'helm-multi-match)
 (require 'helm-cider-util)
 

--- a/helm-cider-repl.el
+++ b/helm-cider-repl.el
@@ -26,7 +26,7 @@
 (require 'cider-repl)
 (require 'cl-lib)
 (require 'subr-x)
-(require 'helm)
+(require 'helm-core)
 
 
 ;;;; Customize
@@ -119,14 +119,14 @@ Useful when the candidate longer than `helm-cider-repl-history-max-lines' lines.
                 (let ((inhibit-read-only t))
                   (erase-buffer)
                   (insert candidate))))
-      (if (and (helm-attr 'previewp)
-               (string= candidate (helm-attr 'current-candidate)))
+      (if (and (helm-get-attr 'previewp)
+               (string= candidate (helm-get-attr 'current-candidate)))
           (progn
             (kill-buffer buf)
-            (helm-attrset 'previewp nil))
+            (helm-set-attr 'previewp nil))
         (preview candidate)
-        (helm-attrset 'previewp t)))
-    (helm-attrset 'current-candidate candidate)))
+        (helm-set-attr 'previewp t)))
+    (helm-set-attr 'current-candidate candidate)))
 
 (defun helm-cider-repl--history-source ()
   "Source for Helm CIDER REPL history."

--- a/helm-cider-spec.el
+++ b/helm-cider-spec.el
@@ -113,14 +113,14 @@ SPEC-NAME is a spec keyword string."
 
 (defun helm-cider-spec--persistent-action (candidate)
   "Persistent action for Helm CIDER apropos."
-  (if (and (helm-attr 'spec-lookup-p)
-           (string= candidate (helm-attr 'current-candidate)))
+  (if (and (helm-get-attr 'spec-lookup-p)
+           (string= candidate (helm-get-attr 'current-candidate)))
       (progn
         (kill-buffer cider-browse-spec-buffer)
-        (helm-attrset 'spec-lookup-p nil))
+        (helm-set-attr 'spec-lookup-p nil))
     (cider-browse-spec--browse candidate)
-    (helm-attrset 'spec-lookup-p t))
-  (helm-attrset 'current-candidate candidate))
+    (helm-set-attr 'spec-lookup-p t))
+  (helm-set-attr 'current-candidate candidate))
 
 (defun helm-cider-spec--source (ns spec-names &optional follow)
   "Helm source for specs in namespace NS.

--- a/helm-cider-util.el
+++ b/helm-cider-util.el
@@ -102,14 +102,14 @@ TYPE values include \"function\", \"macro\", etc."
   "Persistent action calling `cider-doc-lookup' on CANDIDATE."
   (cider-ensure-connected)
   (cider-ensure-op-supported "info")
-  (if (and (helm-attr 'doc-lookup-p)
-           (string= candidate (helm-attr 'current-candidate)))
+  (if (and (helm-get-attr 'doc-lookup-p)
+           (string= candidate (helm-get-attr 'current-candidate)))
       (progn
         (kill-buffer cider-doc-buffer)
-        (helm-attrset 'doc-lookup-p nil))
+        (helm-set-attr 'doc-lookup-p nil))
     (cider-doc-lookup candidate)
-    (helm-attrset 'doc-lookup-p t))
-  (helm-attrset 'current-candidate candidate))
+    (helm-set-attr 'doc-lookup-p t))
+  (helm-set-attr 'current-candidate candidate))
 
 (defmacro wrap-helm-cider-action (f &optional ops)
   "Wrap Helm CIDER actions.

--- a/helm-cider.el
+++ b/helm-cider.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016-2022 Tianxiang Xiong
 
 ;; Author: Tianxiang Xiong <tianxiang.xiong@gmail.com>
-;; Package-Requires: ((emacs "26") (cider "1.0") (helm-core "2.8"))
+;; Package-Requires: ((emacs "26") (cider "1.0") (helm-core "3.7.0"))
 ;; Keywords: cider, clojure, helm, languages
 ;; URL: https://github.com/clojure-emacs/helm-cider
 ;; Version: 0.5.0
@@ -32,7 +32,7 @@
 
 (require 'cider)
 (require 'cl-lib)
-(require 'helm)
+(require 'helm-core)
 (require 'helm-cider-cheatsheet)
 (require 'helm-cider-repl)
 (require 'helm-cider-spec)


### PR DESCRIPTION
- helm-core no longer bundles helm.el
- Replace deprecated functions

Its melpa recipe is https://github.com/melpa/melpa/blob/master/recipes/helm-core